### PR TITLE
Fixing an invalid multibyte sequence

### DIFF
--- a/lib/highrise/rfc822.rb
+++ b/lib/highrise/rfc822.rb
@@ -25,7 +25,8 @@ module Highrise
       word = "(?:#{atom}|#{quoted_string})"
       domain = "#{sub_domain}(?:\\x2e#{sub_domain})*"
       local_part = "#{word}(?:\\x2e#{word})*"
-      addr_spec = "#{local_part}\\x40#{domain}"
+      # addr_spec = "#{local_part}\\x40#{domain}"
+      addr_spec = Regexp.new("#{local_part}\\x40#{domain}", nil, 'n')
       pattern = /\A#{addr_spec}\z/
     end
   end


### PR DESCRIPTION
http://stackoverflow.com/questions/3588826/invalid-multibyte-escape-after-upgrade-to-rails-3-and-ruby-1-9-2-dtext
